### PR TITLE
Working on QoL improvements

### DIFF
--- a/airootfs/usr/share/vx-img/flash-image.sh
+++ b/airootfs/usr/share/vx-img/flash-image.sh
@@ -283,9 +283,7 @@ if [ $_hashash == 1 ]; then
     cat /usr/share/vx-img/image.sha256sum 
 
     echo "Computing hash..."
-    # The fancy syntax around _finalsize makes the gigabyte indicator lowercase,
-    # so it works correctly with pv. 
-    head -c $_finalsize "$_disk" | pv -s "${_finalsize,,}" | sha256sum
+    head -c $_finalsize "$_disk" | pv -s "${_finalsize}" | sha256sum
 fi
 
 # TODO make sure this works on every device

--- a/airootfs/usr/share/vx-img/flash-image.sh
+++ b/airootfs/usr/share/vx-img/flash-image.sh
@@ -69,14 +69,6 @@ if [[ $_surface == 0 && $_haskeys == 0 ]]; then
     fi
 fi
 
-echo "Flashing a new image to the hard disk. This will destroy any existing data on the disk. Continue? [y/N]:"
-
-read -r answer
-
-if [[ $answer != 'y' && $answer != 'Y' ]]; then
-    exit
-fi
-
 clear
 
 data=$(lsblk -x SIZE -nblo NAME,LABEL,SIZE,TYPE | grep "Data" | awk '{ print $1 }')
@@ -274,8 +266,16 @@ while true; do
     break
 done
 
-echo "Flashing image $_path/$_toflash to disk $_disk"
+echo "Flashing image $_path/$_toflash to disk $_disk. Continue? [y/N]"
+
+read -r answer
+
+if [[ $answer != 'y' && $answer != 'Y' ]]; then
+    exit
+fi
+
 $_compression -c -d $_path/"$_toflash" | pv -s "${_finalsize}" > "$_disk"
+
 
 if [ $_hashash == 1 ]; then 
     echo "Now checking that the write was successful."

--- a/airootfs/usr/share/vx-img/flash-image.sh
+++ b/airootfs/usr/share/vx-img/flash-image.sh
@@ -112,7 +112,7 @@ mount "${_datadisk}3" /mnt
 echo "Mounted data disk ${_datadisk} on /mnt"
 
 # Expected file naming scheme
-_match="^\d+G-\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\+\d{2}:\d{2}-.*\.img\.gz$"
+_match="^\d+G-\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\+|-)\d{2}:\d{2}-.*\.img\.gz$"
 _sizematch="^\d+G"
 
 
@@ -129,7 +129,6 @@ _matches=()
 for f in "$_path"/*; do
     _filename="${f##*/}"
     _extension="${_filename##*.}"
-    echo "$_filename"
 
     if (echo "$_filename" | grep -Po "$_match") ; then
         _matches+=("$_filename")
@@ -154,7 +153,7 @@ if [[ "${#_matches[@]}" == 1 ]]; then
 elif [[ -n ${_matches[0]} ]]; then
     echo "Found several images that match the expected format."
     unset answer
-    menu _matches "Please select an image to flash" 
+    menu "${_matches[@]}" "Please select an image to flash" 
 
     if [[ $err == 1 ]]; then
         echo "Something went wrong, please try again."
@@ -175,7 +174,7 @@ elif [[ "${#_images[@]}" == 1 ]]; then
 else
     echo "Found the following images that might work."
     unset answer
-    menu _images "Please select an image to flash" 
+    menu "${_images[@]}" "Please select an image to flash" 
 
     if [[ $err == 1 ]]; then
         echo "Something went wrong, please try again."
@@ -231,7 +230,7 @@ while true; do
     fi
 
     unset answer
-    menu disks "Which disk would you like to flash? Default:" 
+    menu "${disks[@]}" "Which disk would you like to flash? Default:" 
 
     if [[ -n $err ]]; then
         echo "Something went wrong. Please try again."

--- a/airootfs/usr/share/vx-img/flash-image.sh
+++ b/airootfs/usr/share/vx-img/flash-image.sh
@@ -226,7 +226,7 @@ _disk="/dev/nvme0n1"
 # Get our image size in raw bytes
 _size=$(numfmt --from=iec "${_finalsize}")
 
-#clear
+clear
 echo "Found the following disks to flash:"
 while true; do
 
@@ -248,25 +248,28 @@ while true; do
     if [[ -z ${disks[0]} ]]; then
         echo "There are no disks big enough for this image! Exiting..."
         exit
-    fi
+    elif [[ "${#fixed_disks[@]}" == 1 ]]; then
+        _disk=$(echo "${fixed_disks[0]}" | cut -d ' ' -f 1)
+    else 
+        unset answer
+        menu "${fixed_disks[@]}" "Which disk would you like to flash? Default:" 
 
-    unset answer
-    menu "${fixed_disks[@]}" "Which disk would you like to flash? Default:" 
-
-    if [[ $err == 1 ]]; then
-        echo "Something went wrong. Please try again."
-    fi 
-
-    if [[ -n $answer ]]; then
-        selected=$(echo "${fixed_disks[answer-1]}" | cut -d ' ' -f 1)
-
-        if [[ -z $selected ]]; then
-            echo "Invalid selection, starting over"
+        if [[ $err == 1 ]]; then
+            echo "Something went wrong. Please try again."
             continue
+        fi 
+
+        if [[ -n $answer ]]; then
+            selected=$(echo "${fixed_disks[answer-1]}" | cut -d ' ' -f 1)
+
+            if [[ -z $selected ]]; then
+                echo "Invalid selection, starting over"
+                continue
+            fi
+            _disk="/dev/$selected"
+        else
+            _disk="/dev/$(echo "${fixed_disks[-1]}" | cut -d ' ' -f 1)"
         fi
-        _disk="/dev/$selected"
-    else
-        _disk="/dev/$(echo "${fixed_disks[-1]}" | cut -d ' ' -f 1)"
     fi
     break
 done

--- a/airootfs/usr/share/vx-img/flash-image.sh
+++ b/airootfs/usr/share/vx-img/flash-image.sh
@@ -235,20 +235,29 @@ while true; do
     # dump newlines
     disks=("${disks[@]//$'\n'/}")
 
+    # remove the data disk, since we don't want to flash it.
+    fixed_disks=()
+    for value in "${disks[@]}"; do
+        name=$(echo "$value" | cut -d ' ' -f 1)
+        if [[ "$_datadisk" != *"$name"* ]]; then
+            fixed_disks+=("$value")
+        fi
+    done
+
     if [[ -z ${disks[0]} ]]; then
         echo "There are no disks big enough for this image! Exiting..."
         exit
     fi
 
     unset answer
-    menu "${disks[@]}" "Which disk would you like to flash? Default:" 
+    menu "${fixed_disks[@]}" "Which disk would you like to flash? Default:" 
 
     if [[ -n $err ]]; then
         echo "Something went wrong. Please try again."
     fi 
 
     if [[ -n $answer ]]; then
-        selected=${disks[answer-1]}
+        selected=${fixed_disks[answer-1]}
 
         if [[ -z $selected ]]; then
             echo "Invalid selection, starting over"
@@ -256,7 +265,7 @@ while true; do
         fi
         _disk="/dev/$selected"
     else
-        _disk="/dev/${disks[-1]}"
+        _disk="/dev/${fixed_disks[-1]}"
     fi
     break
 done


### PR DESCRIPTION
This PR streamlines the user flow, relying on smart defaults. If everything happens as default (there is only one image, it has the correct file name, and only one disk to flash), the user only has to press enter one time to flash an image. Straying from the default case presents the users with progressively more and more prompts depending on how deviant their case is. 

Note @carolinemodic: I used disk labels to autodetect the Ventoy data partition, so I don't think we actually need to create a different boot entry for the happy path. 