### PR TITLE
fixing decimal point file size bug

### DIFF
--- a/airootfs/usr/share/vx-img/flash-image.sh
+++ b/airootfs/usr/share/vx-img/flash-image.sh
@@ -316,7 +316,10 @@ fi
 # If the size of the image is decimal, chop off the decimal point and after so
 # pv doesn't choke on it. This is fine, since pv is only using the size to
 # compute status percentages and will still push the whole file to the disk.
-statussize=$(echo "$_finalsize" | cut -d '.' -f 1)
+statussize="$(echo "$_finalsize" | cut -d '.' -f 1)"
+if ! (echo "$statussize" | grep -qo "G"); then
+    statussize="${statussize}G"
+fi 
 $_compression -c -d $_path/"$_toflash" | pv -s "${statussize}" > "$_disk"
 
 sleep 3

--- a/airootfs/usr/share/vx-img/flash-image.sh
+++ b/airootfs/usr/share/vx-img/flash-image.sh
@@ -313,16 +313,20 @@ if [[ $answer != 'y' && $answer != 'Y' ]]; then
     exit
 fi
 
-$_compression -c -d $_path/"$_toflash" | pv -s "${_finalsize}" > "$_disk"
+# If the size of the image is decimal, chop off the decimal point and after so
+# pv doesn't choke on it. This is fine, since pv is only using the size to
+# compute status percentages and will still push the whole file to the disk.
+statussize=$(echo "$_finalsize" | cut -d '.' -f 1)
+$_compression -c -d $_path/"$_toflash" | pv -s "${statussize}" > "$_disk"
 
-
+sleep 3
 if [ $_hashash == 1 ]; then 
     echo "Now checking that the write was successful."
     echo "The hash should be:"
     cat /usr/share/vx-img/image.sha256sum 
 
     echo "Computing hash..."
-    head -c $_finalsize "$_disk" | pv -s "${_finalsize}" | sha256sum
+    head -c $_finalsize "$_disk" | pv -s "${statussize}" | sha256sum
 fi
 
 # TODO make sure this works on every device

--- a/airootfs/usr/share/vx-img/flash-image.sh
+++ b/airootfs/usr/share/vx-img/flash-image.sh
@@ -143,7 +143,7 @@ else
         break
     done
 
-    mount "${_datadisk}${part}" /mnt
+    mount "/dev/${part}" /mnt
 fi
 
 


### PR DESCRIPTION
If the filename has a decimal point in the file size, pv will choke on it. Strip off the decimal point and everything after so that doesn't happen. 