### PR TITLE
Altering naming conventions

### DIFF
--- a/airootfs/usr/share/vx-img/flash-image.sh
+++ b/airootfs/usr/share/vx-img/flash-image.sh
@@ -155,7 +155,7 @@ else
 fi
 
 # Expected file naming scheme
-_match="^\d+(\.\d)*G-\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\+|-)\d{2}:\d{2}-.*\.img\.gz$"
+_match="^\d+(\.\d)*G-\d{4}-\d{2}-\d{2}T\d{2}(:|_|\s)\d{2}(:|_|\s)\d{2}(\+|-)\d{2}(:|_|\s)\d{2}-.*\.img\.gz$"
 _sizematch="^\d+(\.\d)*G"
 
 

--- a/airootfs/usr/share/vx-img/scrape-image.sh
+++ b/airootfs/usr/share/vx-img/scrape-image.sh
@@ -79,7 +79,7 @@ read -r _filename
 _path="/mnt"
 
 
-_date=$(date -I'seconds')
+_date=$(date -I'seconds' | sed -s 's/:/_/g')
 _size=$(lsblk -nlo NAME,TYPE,SIZE | grep "disk" | grep "${_diskname}" | awk '{print $3}')
 _fullname="/mnt/${_size}-${_date}-${_filename}"
     


### PR DESCRIPTION
* scraped images will now use underscores as separators in the timestamp
* images that are automatically detected may now use colons, spaces, or
  underscores in their timestamps

Closes #40.