### PR TITLE
Copies /vx/config from one install to the next

### DIFF
--- a/airootfs/usr/share/vx-img/flash-image.sh
+++ b/airootfs/usr/share/vx-img/flash-image.sh
@@ -143,7 +143,6 @@ vg=$(vgscan | sed -s 's/.*"\(.*\)".*/\1/g')
 
 if [[ -n $vg ]]; then
 
-    # Mount the root partition so symlinks are preserved.
     dir=$(find "/dev/$vg" -name "var")
     mount "$dir" /mnt
 

--- a/airootfs/usr/share/vx-img/flash-image.sh
+++ b/airootfs/usr/share/vx-img/flash-image.sh
@@ -441,7 +441,7 @@ fi
 
 umount /mnt
 
-# Now that we've flashed the image, but /vx/config back if it exists.
+# Now that we've flashed the image, put /vx/config back if it exists.
 if [ -e "vx-config.tar.gz" ]; then
     vg=$(vgscan | sed -s 's/.*"\(.*\)".*/\1/g')
 

--- a/packages.x86_64
+++ b/packages.x86_64
@@ -17,3 +17,4 @@ amd-ucode
 dmidecode
 terminus-font
 mokutil
+lvm2


### PR DESCRIPTION
Currently detects if the system that's being flash has an existing vx install, tars up /vx/config, flashes, then untars and writes back /vx/config. 