### PR TITLE
Resetting the systemd-boot timeout to 3s

### DIFF
--- a/efiboot/loader/loader.conf
+++ b/efiboot/loader/loader.conf
@@ -1,2 +1,2 @@
-timeout 1
+timeout 3
 default 02-archiso-x86_64-ram-linux.conf


### PR DESCRIPTION
## Overview
Fixes the systemd-boot menu timeout being too short (issue #49). 

## Demo Video or Screenshot
![Screenshot_archlinux_2022-05-26_13:26:02](https://user-images.githubusercontent.com/2686765/170542302-50c12117-b69c-44cf-9dd3-242bd589f25b.png)

## Testing Plan 
N/A
