### PR TITLE
Bernhard/detect keys

### DIFF
--- a/airootfs/usr/share/vx-img/flash-image.sh
+++ b/airootfs/usr/share/vx-img/flash-image.sh
@@ -39,10 +39,8 @@ else
 fi
 
 
-# TODO use efi-readvar to detect if our keys are already on this device
-_haskeys=1
 
-if [[ $_surface == 0 && $_haskeys == 0 ]]; then
+if [[ $_surface == 0 ]]; then
     echo "Writing new secure boot keys to the device. Proceed? [y/N]:"
 
     read -r answer
@@ -55,6 +53,22 @@ if [[ $_surface == 0 && $_haskeys == 0 ]]; then
             exit
         fi
     else
+        if [[ $_surface == 0 ]]; then
+            _setup=$(mokutil --sb-state | grep -q "Setup Mode")
+
+            if [[ -z $setup ]]; then
+                echo "Device is not in Setup Mode."
+                echo "Please reboot into the BIOS and enter Setup Mode before continuing."
+                echo "Reboot now? [Y/n]:"
+                read -r answer
+
+                if [[ $answer != 'n' && $answer != 'N' ]]; then
+                    reboot 
+                else
+                    exit
+                fi
+            fi
+        fi
         SUCCESS=1
         efi-updatevar -f /etc/efi-keys/DB.auth db && efi-updatevar -f /etc/efi-keys/KEK.auth KEK && efi-updatevar -f /etc/efi-keys/PK.auth PK || SUCCESS=0
 

--- a/airootfs/usr/share/vx-img/flash-image.sh
+++ b/airootfs/usr/share/vx-img/flash-image.sh
@@ -74,7 +74,7 @@ if [[ $_surface == 0  && $_haskeys == 0 ]]; then
                 read -r answer
 
                 if [[ $answer != 'n' && $answer != 'N' ]]; then
-                    reboot 
+                    systemctl reboot --firmware-setup
                 else
                     exit
                 fi

--- a/airootfs/usr/share/vx-img/flash-image.sh
+++ b/airootfs/usr/share/vx-img/flash-image.sh
@@ -40,20 +40,16 @@ fi
 
 _haskeys=0
 if mokutil --pk > /dev/null; then
-    echo "Found PK"
     # Make sure the SB keys are ours
     # TODO do something fancier once we've decided on our keys
     _pk=$(mokutil --pk | grep -aq "VotingWorks" && echo 1 || echo 0)
     _kek=$(mokutil --kek | grep -aq "VotingWorks" && echo 1 || echo 0)
     _db=$(mokutil --db | grep -aq "VotingWorks" && echo 1 || echo 0)
 
-    echo "$_pk $_kek $_db"
     if [[ $_pk == 1 && $_kek == 1 && $_db == 1 ]]; then
         _haskeys=1
     fi
 fi
-
-echo $_haskeys
 
 if [[ $_surface == 0  && $_haskeys == 0 ]]; then
     echo "Writing new secure boot keys to the device. Proceed? [y/N]:"

--- a/airootfs/usr/share/vx-img/flash-image.sh
+++ b/airootfs/usr/share/vx-img/flash-image.sh
@@ -38,9 +38,24 @@ else
     _surface=0
 fi
 
+_haskeys=0
+if mokutil --pk > /dev/null; then
+    echo "Found PK"
+    # Make sure the SB keys are ours
+    # TODO do something fancier once we've decided on our keys
+    _pk=$(mokutil --pk | grep -aq "VotingWorks" && echo 1 || echo 0)
+    _kek=$(mokutil --kek | grep -aq "VotingWorks" && echo 1 || echo 0)
+    _db=$(mokutil --db | grep -aq "VotingWorks" && echo 1 || echo 0)
 
+    echo "$_pk $_kek $_db"
+    if [[ $_pk == 1 && $_kek == 1 && $_db == 1 ]]; then
+        _haskeys=1
+    fi
+fi
 
-if [[ $_surface == 0 ]]; then
+echo $_haskeys
+
+if [[ $_surface == 0  && $_haskeys == 0 ]]; then
     echo "Writing new secure boot keys to the device. Proceed? [y/N]:"
 
     read -r answer

--- a/packages.x86_64
+++ b/packages.x86_64
@@ -16,3 +16,4 @@ intel-ucode
 amd-ucode
 dmidecode
 terminus-font
+mokutil


### PR DESCRIPTION
## Overview

Ensures that the target machine is in Setup Mode or has VotingWorks keys on it already. Starts to address https://github.com/votingworks/vx-iso/issues/3

## Demo Video or Screenshot

Sort of difficult to show steps that aren't there anymore. 

## Testing Plan 

Tested in a VM, will test on hardware. 
