### PR TITLE
Fixing Surface Go boot entry

### DIFF
--- a/airootfs/usr/share/vx-img/flash-image.sh
+++ b/airootfs/usr/share/vx-img/flash-image.sh
@@ -463,24 +463,26 @@ if [ -e "vx-config.tar.gz" ]; then
 fi
 
 # TODO make sure this works on every device
-echo "adding a boot entry for Debian shim"
-efibootmgr \
-	--create \
-	--disk "$_datadisk" \
-	--part 1 \
-	--label "grub" \
-	--loader "\\EFI\\debian\\shimx64.efi" \
-    --quiet
 
-
-echo "adding a boot entry for VxLinux"
-efibootmgr \
-	--create \
-	--disk "$_datadisk" \
-	--part 1 \
-	--label "VxLinux" \
-	--loader "\\EFI\\debian\\VxLinux-signed.efi" \
-    --quiet
+if [ $_surface == 1 ]; then
+    echo "adding a boot entry for Debian shim"
+    efibootmgr \
+        --create \
+        --disk "$_datadisk" \
+        --part 1 \
+        --label "grub" \
+        --loader "\\EFI\\debian\\shimx64.efi" \
+        --quiet
+else
+    echo "adding a boot entry for VxLinux"
+    efibootmgr \
+        --create \
+        --disk "$_datadisk" \
+        --part 1 \
+        --label "VxLinux" \
+        --loader "\\EFI\\debian\\VxLinux-signed.efi" \
+        --quiet
+fi
 
 clear
 echo "The flash was successful! Press Return to reboot in 5 seconds."


### PR DESCRIPTION
## Overview
Makes sure that the correct boot entry is setup when flashing on a Surface Go so that Secure Boot works. 

## Demo Video or Screenshot
N/A
## Testing Plan 
Manually tested. 
