### PR TITLE
helper scripts for SLI and ensure the USB syncs after copy

### DIFF
--- a/roles/vx-iso/tasks/remount_usb.yaml
+++ b/roles/vx-iso/tasks/remount_usb.yaml
@@ -14,6 +14,6 @@
   become: true
   command: eject -t {{ usb_disk_path }}
 
-- name: Sleep 5 seconds to let the OS recognize the USB (Make this better)
+- name: Sleep 5 seconds to let the OS recognize the USB
   command: sleep 5
 

--- a/roles/vx-iso/tasks/vx-img.yaml
+++ b/roles/vx-iso/tasks/vx-img.yaml
@@ -79,3 +79,6 @@
     src: "{{ img_file }}"
     dest: "{{ data_mnt.stdout }}/"
     remote_src: true
+
+- name: Sync the USB to ensure all data has been written. (This may take a few minutes.)
+  ansible.builtin.command: /usr/bin/sync

--- a/scripts/copy-image.sh
+++ b/scripts/copy-image.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+if [[ $# -ne 1 ]]; then
+  echo "Usage: $0 /path/to/img.lz4"
+  exit 1
+fi
+
+set -euo pipefail
+
+img_file=$1
+debian_major_version=$(cat /etc/debian_version | cut -d'.' -f1)
+local_user=`logname`
+local_user_home_dir=$( getent passwd "${local_user}" | cut -d: -f6 )
+
+if [[ ! -f .virtualenv/ansible/bin/activate ]]; then
+  echo "Installing Ansible..."
+  sudo ./scripts/install-ansible.sh online
+  echo "Ansible installation is complete."
+fi
+
+if [[ "$debian_major_version" == "12" ]]; then
+  source .virtualenv/ansible/bin/activate
+fi
+
+echo "Preparing to copy ${img_file} to USB..."
+sleep 3
+ansible-playbook playbooks/vx-iso/flash_vx-img.yaml -e "img_file=${img_file}"
+
+echo "${img_file} has been copied to the USB."
+
+exit 0

--- a/scripts/install-ansible.sh
+++ b/scripts/install-ansible.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+debian_major_version=$(cat /etc/debian_version | cut -d'.' -f1)
+system_architecture=$(uname -m)
+local_user=`logname`
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+function apt_install ()
+{
+  if [[ "$debian_major_version" == "12" ]]; then
+    local python_packages="python3 python3-pip python3-virtualenv"
+  else
+    local python_packages="python3.9 python3-pip"
+  fi
+
+  apt-get install -y ${python_packages}
+}
+
+function pip_install ()
+{
+
+  if [[ "$debian_major_version" == "12" ]]; then
+    cd ${DIR}/..
+    mkdir -p .virtualenv
+    cd .virtualenv && virtualenv ansible
+    cd ..
+    source .virtualenv/ansible/bin/activate
+  fi
+
+  pip3 install ansible passlib
+}
+
+apt_install
+pip_install
+
+echo "Done"
+exit 0


### PR DESCRIPTION
This PR is primarily for adding convenience scripts to simplify copying an image file to USB. It also adds a `sync` call after copying to the USB to ensure the image is completely written to the USB.