### PR TITLE
set TZ to UTC to avoid interactive prompt on any menu action

### DIFF
--- a/airootfs/etc/localtime
+++ b/airootfs/etc/localtime
@@ -1,0 +1,1 @@
+/usr/share/zoneinfo/UTC


### PR DESCRIPTION
Explicitly sets the timezone to UTC to fix an interactive prompt on each menu selection.
