### PR TITLE
Usability and functional improvements for creating install and image usb drives

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,50 +1,31 @@
-# vx-iso
-This repo contains the configuration necessary for creating an Arch Linux-based install stick that can be used to write verified VotingWorks images to hardware. **NOTE** this must be run on an Arch Linux system, as the `mkarchiso` program depends on having Arch utilities like `pacstrap` available to it. First, install `mkarchiso` and `git`: 
-
-```
-sudo pacman -S archiso git
-```
-
-Clone the repo and build the image:
-```bash
-git clone https://github.com/votingworks/vx-iso
-cd vx-iso
-sudo mkarchiso -v -w /tmp/vxiso-tmp -o out .
-```
-
-The iso file will be created in the `out/` directory. After creating, you can use our Ansible playbooks to automatically prepare each USB drive for use. See below for those steps.
-
 # Setting up USB drives for use with vx-iso and OS images.
 ## USB Requirements
 
-You should use a Linux OS (Debian 12 is our current standard) for any of the below steps.
+You should use a Debian 11 or 12 OS for the below steps.
 
-You'll need two USB drives: one for the vx-iso created by `mkarchiso` and one for the OS image and optional secure boot keys. We recommend a fast, 64GB+ USB drive for the OS image and keys. 
+There are two types of USB drives used for installing VotingWorks images.
+1. An install drive. 
+2. An image (with optional keys) drive.
 
-## Install Ansible
-```
-sudo ./scripts/install-ansible.sh
-```
+We recommend a fast, 64GB+ USB drive for the image drive.
 
-On Debian 12, you will need to activate the ansible virtualenv:
-```
-source .virtualenv/ansible/bin/activate
-```
-
-You can confirm Ansible is installed by running: `ansible --version`
-
-## Installing the .iso file
-1. Ensure your USB drive is inserted
+## Creating an install drive
+1. Ensure your USB drive is inserted and accessible to the VM or system you are using
 2. Run: 
-```sudo ansible-playbook playbooks/vx-iso/flash_vx-iso.yaml -e "iso_file=/path/to/your/iso"```
+```./scripts/create-install-drive.sh /path/to/install.iso```
 3. Select your USB drive from the menu
 4. Once the .iso file is successfully copied to the USB, you will see a success message.
 
-## Installing the img (and optional keys) file
-1. Ensure your fast, 64GB+ USB drive is inserted. NOTE: This should NOT be the same USB used for the .iso file.
-2. Run: 
-```sudo ansible-playbook playbooks/vx-iso/flash_vx-img.yaml -e "img_file=/path/to/your/img" -e "keys_file=/path/to/your/keys"```
+## Creating an image (with optional secure boot keys) drive
+1. Ensure your fast, 64GB+ USB drive is inserted and accessible to the VM or system you are using. NOTE: This should NOT be the same USB used for the .iso file.
+2. If you are creating a drive with an image AND secure boot keys: 
+```./scripts/copy-image.sh -i /path/to/img.lz4 -k /path/to/keys.tgz```
+   
+   If you are creating a drive with only an image:
+```./scripts/copy-image.sh -i /path/to/img.lz4```
+
 3. Select your USB drive from the menu
 4. Wait for the img to be copied. If you provided keys, they will also be extracted onto the drive.
  
-
+# Creating a vx-iso installer image
+TODO: This requires a significant update due to implementing secure boot support.

--- a/playbooks/flash_vx-iso.yaml
+++ b/playbooks/flash_vx-iso.yaml
@@ -1,5 +1,0 @@
----
-- name: flash vx-iso to usb
-  hosts: localhost
-  roles:
-    - vx-iso

--- a/roles/vx-iso/tasks/main.yaml
+++ b/roles/vx-iso/tasks/main.yaml
@@ -1,21 +1,21 @@
 ---
 
 - name: Get stat for the original iso file
-  stat:
+  ansible.builtin.stat:
     path: "{{ iso_file }}"
   register: iso_stat
   failed_when:
     - not iso_stat.stat.exists
 
 - name: Create the removable device lookup dictionary
-  set_fact:
+  ansible.builtin.set_fact:
     removable_devices: "{{ removable_devices | default({}) | combine({item : ansible_devices[item].model}) }}"
   when: ansible_devices[item].removable == "1"
   with_items:
     - "{{ ansible_devices.keys() }}"
 
 - name: Create the device menu
-  set_fact:
+  ansible.builtin.set_fact:
     device_menu: |
       {{ device_menu | default('') }}
       Name: {{ item.key }} ({{ item.value }})
@@ -24,7 +24,7 @@
 
 - block:
     - name: Prompt for device to flash
-      pause:
+      ansible.builtin.pause:
         prompt: |
           We found the following removable devices:
           {{ device_menu }}
@@ -32,43 +32,43 @@
       register: device_name
  
     - name: Set device var
-      set_fact: 
+      ansible.builtin.set_fact:
         device: "{{ device_name.user_input }}"
 
   when: device is not defined
 
 - name: Set USB disk path var
-  set_fact:
+  ansible.builtin.set_fact:
     usb_disk_path: "/dev/{{ device }}"
 
 - name: Confirm the device exists and is removable
-  stat:
+  ansible.builtin.stat:
     path: "{{ usb_disk_path }}"
   register: usb_disk_stat
   failed_when:
     - not usb_disk_stat.stat.exists or ansible_devices[device].removable != "1"
 
 - name: Get any active mounts
-  shell:
+  ansible.builtin.shell:
     cmd: lsblk -no mountpoint {{ usb_disk_path }} | sed '/^$/d'
   register: lsblk_result
 
 - name: Unmount the USB drive
-  mount: 
+  ansible.posix.mount:
     path: "{{ item }}"
     state: unmounted
   with_items:
     - "{{ lsblk_result.stdout_lines }}"
  
 - name: Copy the vx-iso image to the USB drive. This may take a minute
-  command: dd if={{ iso_file }} of={{ usb_disk_path }} bs=4M 
+  ansible.builtin.command: dd if={{ iso_file }} of={{ usb_disk_path }} bs=4M
   become: true
 
 - name: Simple sanity check of the copied data
-  command: cmp -n {{ iso_stat.stat.size }} {{ iso_file }} {{ usb_disk_path }}
+  ansible.builtin.command: cmp -n {{ iso_stat.stat.size }} {{ iso_file }} {{ usb_disk_path }}
   become: true
   register: cmp_result
 
 - name: Check if the copy was successful
-  debug:
+  ansible.builtin.debug:
     msg: "Flashing the USB device was {{ (cmp_result.rc == 0) | ternary('successful', 'NOT SUCCESSFUL') }}"

--- a/roles/vx-iso/tasks/partition_vx-img.yaml
+++ b/roles/vx-iso/tasks/partition_vx-img.yaml
@@ -3,6 +3,9 @@
 - import_tasks: usb_mgmt.yaml
   when: usb_disk_info is not defined
 
+- name: Ensure the USB drive has been recognized
+  ansible.builtin.command: eject -t {{ usb_disk_path }}
+
 #-- We need to be sure there aren't existing partitions 
 #-- that might not work with our boot process
 - name: Get USB partition information
@@ -11,54 +14,66 @@
     unit: MiB
   register: usb_disk_info
 
-- name: Remove all partitions from USB
-  community.general.parted:
-    device: "{{ usb_disk_path }}"
-    number: '{{ item.num }}'
-    state: absent
-  loop: '{{ usb_disk_info.partitions }}'
+#-- Only re-partition if the existing scheme doesn't match our expected scheme
+#-- You can see the conditions at the end of this block in the large when conditional
+- block:
 
-- name: Create the keys partition
-  community.general.parted:
-    device: "{{ usb_disk_path }}"
-    label: gpt
-    name: 'Keys'
-    number: 1
-    part_end: 20MB
-    fs_type: fat16
-    state: present
+  - name: Remove all partitions from USB
+    community.general.parted:
+      device: "{{ usb_disk_path }}"
+      number: '{{ item.num }}'
+      state: absent
+    loop: '{{ usb_disk_info.partitions }}'
 
-- name: Create the data partition
-  community.general.parted:
-    device: "{{ usb_disk_path }}"
-    label: gpt
-    name: 'Data'
-    number: 2
-    state: present
-    fs_type: ext4
-    part_start: 20MB
-    part_end: "100%"
+  - name: Create the keys partition
+    community.general.parted:
+      device: "{{ usb_disk_path }}"
+      label: gpt
+      name: 'Keys'
+      number: 1
+      part_end: 20MB
+      fs_type: fat16
+      state: present
+
+  - name: Create the data partition
+    community.general.parted:
+      device: "{{ usb_disk_path }}"
+      label: gpt
+      name: 'Data'
+      number: 2
+      state: present
+      fs_type: ext4
+      part_start: 20MB
+      part_end: "100%"
   
-- name: Put a filesystem on the Keys partition
-  filesystem:
-    fstype: vfat
-    dev: "/dev/{{device}}1"
-    force: true
+  - name: Put a filesystem on the Keys partition
+    community.general.filesystem:
+      fstype: vfat
+      dev: "/dev/{{device}}1"
+      force: true
 
-- name: Put a filesystem on the Data partition
-  filesystem:
-    fstype: ext4
-    dev: "/dev/{{device}}2"
-    force: true
+  - name: Put a filesystem on the Data partition
+    community.general.filesystem:
+      fstype: ext4
+      dev: "/dev/{{device}}2"
+      force: true
 
-#-- We rely heavily on the Keys and Data labels 
-#-- Create them explicitly since parted may not
-- name: Create the Keys label
-  become: true
-  command: fatlabel "/dev/{{ device }}1" Keys
+  #-- We rely heavily on the Keys and Data labels
+  #-- Create them explicitly since parted may not
+  - name: Create the Keys label
+    ansible.builtin.command: fatlabel "/dev/{{ device }}1" Keys
+    become: true
 
-- name: Create the Data label
-  become: true
-  command: e2label "/dev/{{ device }}2" Data
+  - name: Create the Data label
+    ansible.builtin.command: e2label "/dev/{{ device }}2" Data
+    become: true
+
+  when: usb_disk_info.partitions | length == 0 or
+        usb_disk_info.partitions[0].name != 'Keys' or
+        usb_disk_info.partitions[0].fstype != 'fat16' or
+        usb_disk_info.partitions[0].num != 1 or
+        usb_disk_info.partitions[1].name != 'Data' or
+        usb_disk_info.partitions[1].fstype != 'ext4' or
+        usb_disk_info.partitions[1].num != 2
 
 - import_tasks: remount_usb.yaml

--- a/roles/vx-iso/tasks/remount_usb.yaml
+++ b/roles/vx-iso/tasks/remount_usb.yaml
@@ -1,19 +1,72 @@
 ---
 
-- name: Sleep 2 seconds
-  command: sleep 2
+- name: Get current USB mounts
+  ansible.builtin.shell:
+    cmd: lsblk -no mountpoint {{ usb_disk_path }} | sed '/^$/d'
+  register: current_mounts
 
 - name: Eject the USB drive
+  ansible.builtin.command: eject {{ usb_disk_path }}
   become: true
-  command: eject {{ usb_disk_path }}
 
-- name: Sleep 2 seconds
-  command: sleep 2
+- name: Wait for the USB to be successfully ejected
+  ansible.builtin.wait_for:
+    path: "{{ item }}"
+    state: absent
+  loop: "{{ current_mounts.stdout_lines }}"
 
 - name: Remount the USB drive
+  ansible.builtin.command: eject -t {{ usb_disk_path }}
   become: true
-  command: eject -t {{ usb_disk_path }}
 
-- name: Sleep 5 seconds to let the OS recognize the USB
-  command: sleep 5
+- name: Wait for the USB to be successfully mounted
+  ansible.builtin.wait_for:
+    path: "{{ item }}"
+    state: present
+  loop: "{{ current_mounts.stdout_lines }}"
 
+- name: If the USB was not mounted, explicitly sleep 5 more seconds
+  ansible.builtin.command: sleep 5
+  when: current_mounts.stdout == ""
+
+- name: Get updated USB mounts
+  ansible.builtin.shell:
+    cmd: lsblk -no mountpoint {{ usb_disk_path }} | sed '/^$/d'
+  register: updated_mounts
+
+#-- If the usb drive is not mounted, manually mount both partitions
+- block:
+    - ansible.builtin.set_fact:
+        tmp_keys_mnt: "/tmp/vx-iso-Keys"
+
+    - ansible.builtin.set_fact:
+        tmp_data_mnt: "/tmp/vx-iso-Data"
+
+    - name: Create a tmp mount for the Keys directory
+      ansible.builtin.file:
+        state: directory
+        path: "{{ tmp_keys_mnt }}"
+        mode: "0755"
+
+    - name: Create a tmp mount for the Data directory
+      ansible.builtin.file:
+        state: directory
+        path: "{{ tmp_data_mnt }}"
+        mode: "0755"
+
+    - name: Mount partition 1 (keys)
+      ansible.posix.mount:
+        src: "{{ usb_disk_path }}1"
+        path: "{{ tmp_keys_mnt }}"
+        state: ephemeral
+        fstype: vfat
+
+    - name: Mount partition 2 (data)
+      ansible.posix.mount:
+        src: "{{ usb_disk_path }}2"
+        path: "{{ tmp_data_mnt }}"
+        state: ephemeral
+        fstype: ext4
+
+  when:
+    updated_mounts.stdout == ""

--- a/roles/vx-iso/tasks/usb_mgmt.yaml
+++ b/roles/vx-iso/tasks/usb_mgmt.yaml
@@ -1,14 +1,14 @@
 ---
 
 - name: Create the removable device lookup dictionary
-  set_fact:
+  ansible.builtin.set_fact:
     removable_devices: "{{ removable_devices | default({}) | combine({item : ansible_devices[item].model}) }}"
   when: ansible_devices[item].removable == "1"
   with_items:
     - "{{ ansible_devices.keys() }}"
 
 - name: Create the device menu
-  set_fact:
+  ansible.builtin.set_fact:
     device_menu: |
       {{ device_menu | default('') }}
       Name: {{ item.key }} ({{ item.value }})
@@ -17,7 +17,7 @@
 
 - block:
     - name: Prompt for device to flash
-      pause:
+      ansible.builtin.pause:
         prompt: |
           We found the following removable devices:
           {{ device_menu }}
@@ -25,29 +25,29 @@
       register: device_name
  
     - name: Set device var
-      set_fact: 
+      ansible.builtin.set_fact:
         device: "{{ device_name.user_input }}"
 
   when: device is not defined
 
 - name: Set USB disk path var
-  set_fact:
+  ansible.builtin.set_fact:
     usb_disk_path: "/dev/{{ device }}"
 
 - name: Confirm the device exists and is removable
-  stat:
+  ansible.builtin.stat:
     path: "{{ usb_disk_path }}"
   register: usb_disk_stat
   failed_when:
     - not usb_disk_stat.stat.exists or ansible_devices[device].removable != "1"
 
 - name: Get any active mounts
-  shell:
+  ansible.builtin.shell:
     cmd: lsblk -no mountpoint {{ usb_disk_path }} | sed '/^$/d'
   register: lsblk_result
 
 - name: Unmount the USB drive
-  mount: 
+  ansible.posix.mount:
     path: "{{ item }}"
     state: unmounted
   with_items:

--- a/roles/vx-iso/tasks/vx-img.yaml
+++ b/roles/vx-iso/tasks/vx-img.yaml
@@ -1,7 +1,7 @@
 ---
 
 - name: Check for existence of img file
-  stat:
+  ansible.builtin.stat:
     path: "{{ img_file }}"
     get_checksum: no
   register: img_file_stat
@@ -9,7 +9,7 @@
     - not img_file_stat.stat.exists
 
 - name: Check for existence of keys archive
-  stat:
+  ansible.builtin.stat:
     path: "{{ keys_file }}"
     get_checksum: no
   register: keys_file_stat
@@ -21,14 +21,12 @@
 
 - import_tasks: partition_vx-img.yaml
 
-- import_tasks: remount_usb.yaml
-
 - name: Get the Keys mountpoint
-  command: lsblk -no mountpoint "/dev/{{ device }}1"
+  ansible.builtin.command: lsblk -no mountpoint "/dev/{{ device }}1"
   register: keys_mnt
 
 - name: Get the Data mountpoint
-  command: lsblk -no mountpoint "/dev/{{ device }}2"
+  ansible.builtin.command: lsblk -no mountpoint "/dev/{{ device }}2"
   register: data_mnt
 
 #-- This may seem excessive, but we need files at Keys/*
@@ -36,27 +34,27 @@
 #-- and put them in the right place
 - block:
     - name: Create a tmp dir to extract keys to
-      tempfile:
+      ansible.builtin.tempfile:
         state: directory
         suffix: keys
       register: tmp_keys_dir
 
     - name: Extract keys
-      unarchive:
+      ansible.builtin.unarchive:
         src: "{{ keys_file }}"
         dest: "{{ tmp_keys_dir.path }}/"
         remote_src: yes
       register: keys_extracted
 
     - name: Find the extracted files
-      find:
+      ansible.builtin.find:
         path: "{{ tmp_keys_dir.path }}/"
         recurse: yes
         file_type: file
       register: tmp_key_files
 
     - name: Copy the files to the USB
-      copy:
+      ansible.builtin.copy:
         src: "{{ item.path }}"
         dest: "{{ keys_mnt.stdout }}/"
         remote_src: true
@@ -64,7 +62,7 @@
         - "{{ tmp_key_files.files }}"
 
     - name: Remove the temp dir and contents
-      file:
+      ansible.builtin.file:
         path: "{{ tmp_keys_dir.path }}"
         state: absent
 
@@ -74,8 +72,8 @@
 
 #-- NOTE: remote_src needs to be true since we operate in localhost mode
 #--       This prevents an unnecessary temporary copy of the file being created
-- name: Copy the OS image to the Data partition. (This make take a few minutes.)
-  copy:
+- name: Copy the OS image to the Data partition. (This may take a few minutes.)
+  ansible.builtin.copy:
     src: "{{ img_file }}"
     dest: "{{ data_mnt.stdout }}/"
     remote_src: true

--- a/roles/vx-iso/tasks/vx-iso.yaml
+++ b/roles/vx-iso/tasks/vx-iso.yaml
@@ -1,7 +1,7 @@
 ---
 
 - name: Get stat for the original iso file
-  stat:
+  ansible.builtin.stat:
     path: "{{ iso_file }}"
   register: iso_stat
   failed_when:
@@ -10,14 +10,14 @@
 - import_tasks: usb_mgmt.yaml
  
 - name: Copy the vx-iso image to the USB drive. This may take a minute
-  command: dd if={{ iso_file }} of={{ usb_disk_path }} bs=4M 
+  ansible.builtin.command: dd if={{ iso_file }} of={{ usb_disk_path }} bs=4M
   become: true
 
 - name: Simple sanity check of the copied data
-  command: cmp -n {{ iso_stat.stat.size }} {{ iso_file }} {{ usb_disk_path }}
+  ansible.builtin.command: cmp -n {{ iso_stat.stat.size }} {{ iso_file }} {{ usb_disk_path }}
   become: true
   register: cmp_result
 
 - name: Check if the copy was successful
-  debug:
+  ansible.builtin.debug:
     msg: "Flashing the USB device was {{ (cmp_result.rc == 0) | ternary('successful', 'NOT SUCCESSFUL') }}"

--- a/scripts/copy-image.sh
+++ b/scripts/copy-image.sh
@@ -1,13 +1,57 @@
 #!/usr/bin/env bash
 
-if [[ $# -ne 1 ]]; then
-  echo "Usage: $0 /path/to/img.lz4"
+function usage {
+  echo "Usage: $0 -i /path/to/img.lz4 [-k /path/to/keys.tgz] [-h]"
+  echo "-i ) Required. This should be the path to an image file."
+  echo "-k ) Optional. This should be the path to a tgz containing Secure Boot keys."
+}
+
+while getopts "i:k:h" opt; do
+  case $opt in
+    i)
+      img_file=$OPTARG;;
+    k)
+      keys_file=$OPTARG;;
+    h)
+      usage
+      exit
+      ;;
+  esac
+done
+
+# Check for required img_file option
+if [[ -z "$img_file" ]]; then
+  usage
   exit 1
+fi
+
+# This will be an array of extra variables to pass to Ansible
+ansible_extra_vars=()
+
+# Verify img_file exists
+if [[ ! -f $img_file ]]; then
+  echo "Error: $img_file is not a valid file."
+  echo "Please verify the path is correct."
+  exit 2
+else
+  ansible_extra_vars+=(--extra-vars "img_file=${img_file}")
+fi
+
+# If the keys_file option was passed, verify the file exists
+if [[ ! -z "$keys_file" && ! -f $keys_file ]]; then
+  echo "Error: $keys_file is not a valid file."
+  echo "Please verify the path is correct."
+  exit 3
+fi
+
+# If the keys_file option was passed, and the file exists,
+# add the option to ansible_extra_vars
+if [[ ! -z "$keys_file" && -f $keys_file ]]; then
+  ansible_extra_vars+=(--extra-vars "keys_file=${keys_file}")
 fi
 
 set -euo pipefail
 
-img_file=$1
 debian_major_version=$(cat /etc/debian_version | cut -d'.' -f1)
 local_user=`logname`
 local_user_home_dir=$( getent passwd "${local_user}" | cut -d: -f6 )
@@ -22,10 +66,13 @@ if [[ "$debian_major_version" == "12" ]]; then
   source .virtualenv/ansible/bin/activate
 fi
 
-echo "Preparing to copy ${img_file} to USB..."
-sleep 3
-ansible-playbook playbooks/vx-iso/flash_vx-img.yaml -e "img_file=${img_file}"
+echo "Refreshing sudo credentials. You may be prompted to re-enter your password."
+sudo -v
 
-echo "${img_file} has been copied to the USB."
+echo "Preparing to copy file(s) to the USB..."
+sleep 2
+ansible-playbook playbooks/vx-iso/flash_vx-img.yaml ${ansible_extra_vars[@]}
+
+echo "The copy is complete. You can safely eject and remove the USB."
 
 exit 0

--- a/scripts/create-install-drive.sh
+++ b/scripts/create-install-drive.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+if [[ $# -ne 1 ]]; then
+  echo "Usage: $0 /path/to/installer.iso"
+  echo "Example: $0 /home/vx/Downloads/vx-iso-2024.03.20-x86_64-Secure-Boot.iso"
+  exit 1
+fi
+
+set -euo pipefail
+
+iso_file=$1
+debian_major_version=$(cat /etc/debian_version | cut -d'.' -f1)
+local_user=`logname`
+local_user_home_dir=$( getent passwd "${local_user}" | cut -d: -f6 )
+
+if [[ ! -f .virtualenv/ansible/bin/activate ]]; then
+  echo "Installing Ansible..."
+  sudo ./scripts/install-ansible.sh
+  echo "Ansible installation is complete."
+fi
+
+if [[ "$debian_major_version" == "12" ]]; then
+  source .virtualenv/ansible/bin/activate
+fi
+
+echo "Refreshing sudo credentials. You may be prompted to re-enter your password."
+sudo -v
+echo "Preparing to copy ${iso_file} to USB..."
+sleep 3
+ansible-playbook playbooks/vx-iso/flash_vx-iso.yaml -e "iso_file=${iso_file}"
+
+echo "A USB install drive has been created from: ${iso_file}"
+
+exit 0


### PR DESCRIPTION
This PR is focused on making the creation of both install and image USB drives simpler, more flexible, and more consistent. Rather than requiring the explicit use of `ansible-playbook` commands and associated environment and syntax, simple script wrappers are now provided (along with documentation updates). 

Of note:

- the use of sleep commands when managing usb drives has been significantly reduced. Instead, Ansible's `wait_for` is used to verify the state of usb drives before performing related operations
- we no longer force re-partitioning of a usb drive. If the drive matches our expected partition scheme, we simply copy files to the drive. This enables the use of usb drives with multiple images. If the drive does not match our expected scheme, we still perform a full re-partition.
- using `sudo -v` before running Ansible playbooks should eliminate an edge-case that caused failure if you had not recently validated your sudo privileges
- being more explicit in regard to task namespacing, e.g. `ansible.builtin.copy` instead of `copy`