### PR TITLE
workaround for the way ext4 automount permissions are applied

### DIFF
--- a/roles/vx-iso/tasks/vx-img.yaml
+++ b/roles/vx-iso/tasks/vx-img.yaml
@@ -78,5 +78,8 @@
     dest: "{{ data_mnt.stdout }}/"
     remote_src: true
 
+- name: Work around ext4 automount permissions
+  ansible.builtin.command: chmod -R 777 "{{ data_mnt.stdout }}"
+
 - name: Sync the USB to ensure all data has been written. (This may take a few minutes.)
   ansible.builtin.command: /usr/bin/sync


### PR DESCRIPTION
EXT4 filesystems are automounted with permissions based on the state of the drive at creation/modification. This can result in requiring sudo privileges to modify contents of the USB drive. This change fixes the issue by making the directory contents accessible to everyone since we can't know the users/uids of all possible environments ahead of time. 