### PR TITLE
Automatically detect size of image being installed

### DIFF
--- a/live-build/includes.chroot/usr/local/bin/flash-image.sh
+++ b/live-build/includes.chroot/usr/local/bin/flash-image.sh
@@ -379,13 +379,16 @@ sleep 3
 clear
 
 if [[ -z $_finalsize ]]; then
-    echo "What is the expected final size of the image, in GB? [64]:"
-    read -r answer
-    _finalsize="${answer}G"
+    #echo "What is the expected final size of the image, in GB? [64]:"
+    #read -r answer
+    #_finalsize="${answer}G"
 
-    if [[ -z "$answer" ]]; then
-        _finalsize="64G"
-    fi
+    #if [[ -z "$answer" ]]; then
+        #_finalsize="64G"
+    #fi
+    lz4cat "$_path/$_toflash" 2>/dev/null | dd of=/tmp/boot_header bs=1M count=1
+    sectors=$(file /tmp/boot_header | grep -o '[0-9]\+ sectors' | cut -d' ' -f1
+    _finalsize=$(( ${sectors} * 512 / 1024 / 1024 / 1024 + 1 ))G
 fi
 
 _disk="/dev/nvme0n1"

--- a/live-build/includes.chroot/usr/local/bin/flash-image.sh
+++ b/live-build/includes.chroot/usr/local/bin/flash-image.sh
@@ -387,7 +387,7 @@ if [[ -z $_finalsize ]]; then
         #_finalsize="64G"
     #fi
     lz4cat "$_path/$_toflash" 2>/dev/null | dd of=/tmp/boot_header bs=1M count=1
-    sectors=$(file /tmp/boot_header | grep -o '[0-9]\+ sectors' | cut -d' ' -f1
+    sectors=$(file /tmp/boot_header | grep -o '[0-9]\+ sectors' | cut -d' ' -f1)
     _finalsize=$(( ${sectors} * 512 / 1024 / 1024 / 1024 + 1 ))G
 fi
 

--- a/live-build/vxiso.list.chroot
+++ b/live-build/vxiso.list.chroot
@@ -15,6 +15,7 @@ dialog
 dmidecode
 efibootmgr
 efitools
+file
 libtss2-tcti-tabrmd0
 linux-image-amd64
 lvm2


### PR DESCRIPTION
This PR removes the manual prompt asking for final size of the image being installed. Instead, it extracts the necessary boot header information and calculates the size from that info. If the size can't be determined, we default to 64G. 
