### PR TITLE
Update SHV script

### DIFF
--- a/live-build/includes.chroot/usr/local/bin/compute-system-hash.sh
+++ b/live-build/includes.chroot/usr/local/bin/compute-system-hash.sh
@@ -23,3 +23,10 @@ else
     echo "Signed Hash: UNVERIFIED"
     read -p "This is not a signed image. Press Enter to continue."
 fi
+
+# TODO/Future: Add QR code support that can be verified at check.voting.works
+# qrencode -t ANSI "payload" -o -
+# where payload is the properly formatted and signed payload
+#
+
+exit 0

--- a/live-build/includes.chroot/usr/local/bin/compute-system-hash.sh
+++ b/live-build/includes.chroot/usr/local/bin/compute-system-hash.sh
@@ -2,14 +2,19 @@
 
 trap '' SIGINT SIGTSTP SIGTERM
 
+set -euo pipefail
+
 #hardcoded to nvme for now
 mount -o ro /dev/nvme0n1p1 /mnt
 
 # Check for the VxLinux-signed.efi and handle if it doesn't exist
-# Not dealing with it for now
 # That aside, we're using the strings command to extract the verity hash
 # from the signed efi binary to later use when calculating the SHV
-VERITY_HASH=$(strings /mnt/EFI/debian/VxLinux-signed.efi | grep -o verity.hash=[a-zA-Z0-9]* | cut -d'=' -f2)
+if [[ -f /mnt/EFI/debian/VxLinux-signed.efi ]]; then
+  VERITY_HASH=$(strings /mnt/EFI/debian/VxLinux-signed.efi | grep -o verity.hash=[a-zA-Z0-9]* | cut -d'=' -f2)
+else
+  VERITY_HASH=""
+fi
 
 umount /mnt
 

--- a/live-build/vxiso.list.chroot
+++ b/live-build/vxiso.list.chroot
@@ -24,6 +24,7 @@ mokutil
 network-manager
 openssl
 pv
+qrencode
 systemd
 systemd-sysv
 tpm2-abrmd
@@ -32,3 +33,4 @@ tpm2-tools
 util-linux
 vim
 wget
+xxd


### PR DESCRIPTION
Update the SHV script to calculate the hash in base64 to match how the app is calculating it. In the future, we'll also generate a QR code that can be scanned from this functionality. 

We still need to decide on how to handle where we install images, but for now, assuming an NVME drive.
