### PR TITLE
Improvements: boot order management, image selection

### DIFF
--- a/live-build/includes.chroot/usr/local/bin/flash-image.sh
+++ b/live-build/includes.chroot/usr/local/bin/flash-image.sh
@@ -609,7 +609,7 @@ else
 fi
 
 # Get the new set of boot entries
-efibootmgr -v | grep '/File' | grep -i 'EFI\\debian' > /tmp/new_boot
+efibootmgr -v | grep '/File' | grep -i '\\EFI\\debian' > /tmp/new_boot
 
 new_entry=`diff /tmp/current_boot /tmp/new_boot | grep 'Boot' | cut -d' ' -f2 | cut -d'*' -f1 | sed -e 's/Boot//'`
 


### PR DESCRIPTION
This PR adds several improvements to the vx-iso image installation process.

- If only one image is present in the `Data` directory, it is automatically selected for installation. (You can still cancel the install before it automatically proceeds.)
- Obsolete boot entries from previous installs are automatically deleted. This results in only one VotingWorks boot entry, making it easier to troubleshoot boot issues, and prevents an incorrect boot entry from being used. 
- Adds a more generalized approach to detecting possible USB boot entries across different hardware/bios implementations. This should result in valid USB drives booting automatically, with the exception of bios implementations that do not respect `efibootmgr` boot order changes related to USB drives.

I've also started moving away from the `flash` terminology, in favor of `install`. As we get closer to a hands-free software update process for our customers, `install` feels like a more accessible and understandable term.
