### PR TITLE
add machine id to config persistence check

### DIFF
--- a/live-build/includes.chroot/usr/local/bin/flash-image.sh
+++ b/live-build/includes.chroot/usr/local/bin/flash-image.sh
@@ -260,6 +260,8 @@ function restore_vx_config() {
       if [[ $DEBUG == 1 ]]; then echo "Secure Boot state does not match"; fi
     elif [[ $previous_machine_type != $new_machine_type ]]; then
       if [[ $DEBUG == 1 ]]; then echo "Machine Type does not match"; fi
+    elif [[ $previous_machine_id == "0000" ]]; then
+      if [[ $DEBUG == 1 ]]; then echo "Machine ID is the default"; fi
     elif [[ $previous_qa_state != $new_qa_state ]]; then
       if [[ $DEBUG == 1 ]]; then echo "QA Image state does not match"; fi
     elif [[ $previous_prod_cert_hash != $new_prod_cert_hash ]]; then


### PR DESCRIPTION
During v4.0.2 imaging, we discovered an edge-case related to config persistence. In the event that an image was successfully installed to disk, but it then failed to proceed through config persistence or the config wizard, it can be left in a state that will also result in subsequent installs not going through the config wizard. When this happens, manual intervention is necessary to force the config wizard flow. This PR adds a check to config persistence related to the machine ID. If it's still the default of `0000`, that's good signal that something on the current install is incorrect, so we should not persist the configuration during installation of the newest image.
