### PR TITLE
Force fipsinstall on first boot when config is persisted

### DIFF
--- a/live-build/includes.chroot/usr/local/bin/flash-image.sh
+++ b/live-build/includes.chroot/usr/local/bin/flash-image.sh
@@ -281,6 +281,13 @@ function restore_vx_config() {
     else
       if [[ -d "${vx_config_mnt}/vx/config" && -f "${vx_config_tarball_path}" ]]; then
         tar --extract --file=${vx_config_tarball_path} --gzip --verbose --keep-directory-symlink -C /
+
+	# Since we're bypassing the config wizard, need to run
+	# the fipsinstall step on first boot
+        touch "${vx_config_mnt}/vx/config/RUN_FIPS_INSTALL"
+	chmod 777 "${vx_config_mnt}/vx/config/RUN_FIPS_INSTALL"
+
+	# Don't run basic config wizard since the config was persisted
         rm -f "${vx_config_mnt}/vx/config/RUN_BASIC_CONFIGURATION_ON_NEXT_BOOT" > /dev/null 2>&1
       fi
     fi


### PR DESCRIPTION
To be compliant with FIPS, the `openssl fipsinstall` command must be run on each system. This adds a flag file when config persistence takes place since the basic config wizard (where we originally perform the fipsinstall) will be skipped.
