### PR TITLE
Handle newer USB drives that do not adhere to removable device standards

### DIFF
--- a/live-build/includes.chroot/etc/initramfs-tools/scripts/live-premount/dmverity-root
+++ b/live-build/includes.chroot/etc/initramfs-tools/scripts/live-premount/dmverity-root
@@ -56,16 +56,16 @@ fi
 # since it is possible multiple USB devices could be present
 # It's also possible for the device path naming to differ from the standard
 # /dev/sd[a-z] pattern, so we search for removable devices
-# The key here is looking for the removable device (RM) flag
+# Rather than using the removable device (RM) flag, we are using
+# the device transport type (TRAN) flag. Newer USB drives can show
+# up as not removable, so the RM flag is no longer reliable.
 # We only look for our dm-verity filesystem on partition 1, for context
-echo "#################################"
-echo " Looking for devices"
-echo "#################################"
+echo "Looking for potential usb devices to validate..."
 sleep 5
-lsblk --nodeps -o NAME,RM | awk '$2 == "1"' | cut -d' ' -f1
+lsblk --nodeps -o NAME,TRAN | awk '$2 == "usb" {print $1}'
 sleep 5
 
-for device in `lsblk --nodeps -o NAME,RM | awk '$2 == "1"' | cut -d' ' -f1`
+for device in $(lsblk --nodeps -o NAME,TRAN | awk '$2 == "usb" {print $1}')
 do
   mkdir -p /mnt
   mount /dev/${device}1 /mnt

--- a/live-build/initialize-usb.sh
+++ b/live-build/initialize-usb.sh
@@ -13,10 +13,10 @@ if [[ -z "$usb_path" ]]; then
   exit 1
 fi
 
-is_removable=$(cat /sys/block/$(basename $usb_path)/removable || echo 0)
+drive_type=$(lsblk -n --nodeps -o TRAN ${usb_path} 2>/dev/null)
 
-if [[ $is_removable == 0 ]]; then
-  echo "The device path you specified is not a removable device."
+if [[ $drive_type != "usb" ]]; then
+  echo "The device path you specified is not a usb device."
   echo "Please check the device path ($usb_path) you provided."
   exit 1
 fi

--- a/live-build/install-vx-iso-to-usb.sh
+++ b/live-build/install-vx-iso-to-usb.sh
@@ -15,10 +15,10 @@ if [[ -z "$usb_path" ]]; then
   exit 1
 fi
 
-is_removable=$(cat /sys/block/$(basename $usb_path)/removable || echo 0)
+drive_type=$(lsblk -n --nodeps -o TRAN ${usb_path} 2>/dev/null)
 
-if [[ $is_removable == 0 ]]; then
-  echo "The device path you specified is not a removable device."
+if [[ $drive_type != "usb" ]]; then
+  echo "The device path you specified is not a usb device."
   echo "Please check the device path ($usb_path) you provided."
   exit 1
 fi


### PR DESCRIPTION
This PR addresses newer USB drives that can show up as not-removable (even though they are) via normal methods of determining removable status. Rather than using the `removable` value found via `/sys/block/<device>/removable` or the `RM` flag with the `lsblk` command, we're now checking the device transport type (`TRAN`) value to identify a usb device.
