### PR TITLE
Wait for keypress or USB removal before rebooting

### DIFF
--- a/live-build/includes.chroot/usr/local/bin/flash-image.sh
+++ b/live-build/includes.chroot/usr/local/bin/flash-image.sh
@@ -624,8 +624,10 @@ umount /mnt
 
 restore_vx_config
 
-# Get the current set of boot entries
-efibootmgr -v | grep '/File' | grep -i '\\EFI\\debian' > /tmp/current_boot
+# Get the current set of VxWorks boot entries
+# For now, we rely on our use of the "Installed <date>" notation
+# in boot entries created by VxWorks
+efibootmgr -v | grep -E '\bInstalled [0-9]{8}\b' | grep '/File' | grep -i '\\EFI\\debian' > /tmp/current_boot
 
 boot_label=$(basename ${_toflash%%.img.*})
 install_date=$(date +%Y%m%d)
@@ -651,7 +653,7 @@ else
 fi
 
 # Get the new set of boot entries
-efibootmgr -v | grep '/File' | grep -i '\\EFI\\debian' > /tmp/new_boot
+efibootmgr -v | grep -E '\bInstalled [0-9]{8}\b' | grep '/File' | grep -i '\\EFI\\debian' > /tmp/new_boot
 
 new_entry=`diff /tmp/current_boot /tmp/new_boot | grep 'Boot' | cut -d' ' -f2 | cut -d'*' -f1 | sed -e 's/Boot//'`
 


### PR DESCRIPTION
This PR changes post-install behavior to wait for a key press or USB removal before rebooting. The previous functionality automatically rebooted after 10 seconds, which can be an issue since it will result in rebooting into vx-iso if the drive was not removed. (This also includes https://github.com/votingworks/vx-iso/pull/115 since I'm currently building new images for certification testing)
