### PR TITLE
Make the Data partition writeable without requiring sudo privileges

### DIFF
--- a/live-build/initialize-usb.sh
+++ b/live-build/initialize-usb.sh
@@ -63,7 +63,7 @@ mkdir -p /mnt/live
 
 umount /mnt
 
-echo "Fixing permissions..."
+echo "Setting Data partition permissions..."
 mount "${usb_path}3" /mnt
 chmod 777 /mnt/.
 umount /mnt

--- a/live-build/initialize-usb.sh
+++ b/live-build/initialize-usb.sh
@@ -63,4 +63,9 @@ mkdir -p /mnt/live
 
 umount /mnt
 
+echo "Fixing permissions..."
+mount "${usb_path}3" /mnt
+chmod 777 /mnt/.
+umount /mnt
+
 exit 0

--- a/live-build/install-vx-iso-to-usb.sh
+++ b/live-build/install-vx-iso-to-usb.sh
@@ -56,7 +56,7 @@ sync
 
 umount /mnt
 
-echo "Updating Data partition permissions..."
+echo "Setting Data partition permissions..."
 mount "${usb_path}3" /mnt
 chmod 777 /mnt/.
 umount /mnt

--- a/live-build/install-vx-iso-to-usb.sh
+++ b/live-build/install-vx-iso-to-usb.sh
@@ -56,4 +56,9 @@ sync
 
 umount /mnt
 
+echo "Updating Data partition permissions..."
+mount "${usb_path}3" /mnt
+chmod 777 /mnt/.
+umount /mnt
+
 exit 0


### PR DESCRIPTION
The `Data` partition is an `ext4` filesystem, and permissions are not inherited well across different Linux systems. This PR sets the permissions on that partition to `777` so that sudo is not required when copying files to the partition. This set of permissions is set during USB initialization and installing vx-iso to a USB. 

This closes https://github.com/votingworks/vxsuite/issues/6432