### PR TITLE
require release type in utility scripts

### DIFF
--- a/live-build/bundle-build-assets.sh
+++ b/live-build/bundle-build-assets.sh
@@ -1,7 +1,20 @@
 #!/bin/bash
 
+RELEASE_TYPE=${1:-"field"}
+
+if [[ "${RELEASE_TYPE}" != "field" &&
+      "${RELEASE_TYPE}" != "admin" &&
+      "${RELEASE_TYPE}" != "superadmin" ]]; then
+
+  echo "Usage: $0 [field|admin|superadmin]"
+  echo ""
+  echo "You must specify a valid release type. If none is provided, field will"
+  echo "be used by default."
+  exit 1
+fi
+
 tmp_build_dir="tmp-build-dir"
-bundle_dir="${tmp_build_dir}/assets"
+bundle_dir="${tmp_build_dir}/${RELEASE_TYPE}-assets"
 shellx64_url="https://github.com/pbatard/UEFI-Shell/releases/download/24H2/shellx64.efi"
 shellx64_sha256="b95987046a822088d29d004f622904cd708d467b5268f3b94280de8bf6c7c1b1"
 bootx64_efi="${bundle_dir}/BOOTX64.EFI"

--- a/live-build/extract-build-assets.sh
+++ b/live-build/extract-build-assets.sh
@@ -1,10 +1,12 @@
 #!/bin/bash
 
 vxiso_tarball=$1
+RELEASE_TYPE=${2:-"field"}
 
 if [[ -z "${vxiso_tarball}" ]]; then
-  echo "Usage: $0 /path/to/vxiso.tgz"
-  echo "Example: $0 ./vx-iso-unsigned-20250305.tgz"
+  echo "Usage: $0 /path/to/vxiso.tgz [field|admin|superadmin]"
+  echo ""
+  echo "Example: $0 ./vx-iso-unsigned-20250305.tgz field"
   exit 1
 fi
 
@@ -13,8 +15,19 @@ if [[ ! -f "${vxiso_tarball}" ]]; then
   exit 2
 fi
 
+if [[ "${RELEASE_TYPE}" != "field" &&
+      "${RELEASE_TYPE}" != "admin" &&
+      "${RELEASE_TYPE}" != "superadmin" ]]; then
+
+  echo "Usage: $0 /path/to/vxiso.tgz [field|admin|superadmin]"
+  echo ""
+  echo "You must specify a valid release type. If none is provided, field will"
+  echo "be used by default."
+  exit 1
+fi
+
 tmp_build_dir="tmp-build-dir"
-bundle_dir="${tmp_build_dir}/assets"
+bundle_dir="${tmp_build_dir}/${RELEASE_TYPE}-assets"
 
 if [[ -d "${bundle_dir}" ]]; then
   echo "Removing existing ${bundle_dir}"

--- a/live-build/install-vx-iso-to-usb.sh
+++ b/live-build/install-vx-iso-to-usb.sh
@@ -6,12 +6,31 @@ if [[ $EUID -ne 0 ]]; then
 fi
 
 usb_path=$1
-tmp_build_dir="tmp-build-dir"
-bundle_dir="${tmp_build_dir}/assets"
+RELEASE_TYPE=${2:-"field"}
 
 if [[ -z "$usb_path" ]]; then
-  echo "Usage: $0 /dev/sdX"
+  echo "Usage: $0 /dev/sdX [field|admin|superadmin]"
+  echo ""
   echo "You must specify the device path to the USB, e.g. /dev/sda"
+  exit 1
+fi
+
+if [[ "${RELEASE_TYPE}" != "field" &&
+      "${RELEASE_TYPE}" != "admin" &&
+      "${RELEASE_TYPE}" != "superadmin" ]]; then
+
+  echo "Usage: $0 /dev/sdX [field|admin|superadmin]"
+  echo ""
+  echo "You must specify a valid release type. If none is provided, field will"
+  echo "be used by default."
+  exit 1
+fi
+
+tmp_build_dir="tmp-build-dir"
+bundle_dir="${tmp_build_dir}/${RELEASE_TYPE}-assets"
+if [[ ! -d "${bundle_dir}" ]]; then
+  echo "There is not a valid ${RELEASE_TYPE} release to install."
+  echo "Please extract a vx-iso release via extract-build-assets.sh"
   exit 1
 fi
 

--- a/live-build/lockdown.sh
+++ b/live-build/lockdown.sh
@@ -13,9 +13,21 @@ if [[ $EUID -ne 0 ]]; then
 fi
 
 loopback_img=$1
+RELEASE_TYPE=${2:-"field"}
 
 if [[ -z "$loopback_img" ]]; then
-  echo "Usage: $0 /path/to/vxdbkey.img"
+  echo "Usage: $0 /path/to/vxdbkey.img [field|admin|superadmin]"
+  exit 1
+fi
+
+if [[ "${RELEASE_TYPE}" != "field" &&
+      "${RELEASE_TYPE}" != "admin" &&
+      "${RELEASE_TYPE}" != "superadmin" ]]; then
+
+  echo "Usage: $0 /path/to/vxdbkey.img [field|admin|superadmin]"
+  echo ""
+  echo "You must specify a valid release type. If none is provided, field will"
+  echo "be used by default."
   exit 1
 fi
 
@@ -25,7 +37,7 @@ if [[ ! -f $loopback_img ]]; then
 fi
 
 tmp_build_dir="tmp-build-dir"
-bundle_dir="${tmp_build_dir}/assets"
+bundle_dir="${tmp_build_dir}/${RELEASE_TYPE}-assets"
 bootx64_efi="${bundle_dir}/BOOTX64.EFI"
 vx64_efi="${bundle_dir}/VX64.EFI"
 vxiso_tarball="vx-iso-assets.tgz"


### PR DESCRIPTION
This is an initial solution to a feature request that would use release type asset directories for vx-iso rather than using a shared directory that is overwritten each time. This enables installing different release types without having to extract the image each time you switch between release types.

While this adds some level of convenience, it adds to the complexity of the local user environment when managing different releases. For example, a user could extract a `field` release with the `admin` release type. That would put a valid `field` release under the `admin` assets directory structure. If an older `field` release were still present, it's possible that release could then be installed instead of the most recently extracted. Similarly, a user could intend to install an `admin` release, not realizing a `field` release was most recently extracted there by mistake.

@arsalansufi, I don't want to over-rotate on this, but I'd be interested in whether you think there's value in taking the time and effort to consider something like embedding the release type in a release to help with some of this basic validation? There's probably a follow-up question on whether we should add another check for the release version for many of the same reasons.
